### PR TITLE
disable `<schema>.make` checks at trusted boundaries

### DIFF
--- a/.changeset/curvy-days-swim.md
+++ b/.changeset/curvy-days-swim.md
@@ -1,0 +1,5 @@
+---
+"crosshatch": patch
+---
+
+Disable `<schema>.make` checks at trusted boundaries.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ LanguageModel.generateText({
 
 ## Example Merchant
 
-The following Effect HTTP API route charges and settles USDC on Base. It uses
-[Alchemy](https://github.com/alchemy-run/alchemy)'s single-file
-`Cloudflare.Worker` DX, where platform configuration and the Worker runtime live
-together.
+The following Effect HTTP API route charges and settles USD-denominated
+stablecoins. It uses [Alchemy](https://github.com/alchemy-run/alchemy)'s
+single-file `Cloudflare.Worker` DX, where platform configuration and the Worker
+runtime live together.
 
 ```ts
 import {

--- a/crosshatch/Accept.ts
+++ b/crosshatch/Accept.ts
@@ -32,7 +32,7 @@ export const layer = (denomination: Denomination) =>
         for (const asset of Object.values(denomination)) {
           for (const [namespace, references] of Object.entries(asset)) {
             for (const [reference, physical] of Object.entries(references)) {
-              const chainId = ChainId.make(`${namespace}:${reference}`)
+              const chainId = ChainId.make(`${namespace}:${reference}`, { disableChecks: true })
               for (let acceptedI = 0; acceptedI < accepts.length; acceptedI++) {
                 const accepted = accepts[acceptedI]!
                 if (chainId === accepted.network && physical.asset === accepted.asset) {

--- a/crosshatch/Amount.ts
+++ b/crosshatch/Amount.ts
@@ -28,7 +28,7 @@ export const from = Effect.fnUntraced(function* (input: Input) {
   if (v === undefined || BigDecimal.isNegative(v)) {
     return yield* new InvalidAmountError({ input })
   }
-  return Amount.make(v)
+  return Amount.make(v, { disableChecks: true })
 })
 
 export const parse = (input: string): Effect.Effect<typeof Amount.Type, InvalidAmountError> => {
@@ -39,7 +39,9 @@ export const parse = (input: string): Effect.Effect<typeof Amount.Type, InvalidA
         Option.match({
           onNone: () => new InvalidAmountError({ input }),
           onSome: (decimal) =>
-            BigDecimal.isNegative(decimal) ? new InvalidAmountError({ input }) : Effect.succeed(Amount.make(decimal)),
+            BigDecimal.isNegative(decimal)
+              ? new InvalidAmountError({ input })
+              : Effect.succeed(Amount.make(decimal, { disableChecks: true })),
         }),
       )
 }
@@ -56,17 +58,17 @@ export const toAtomic = (amount: typeof Amount.Type, unit: AtomicUnit): typeof A
       mode: unit.rounding ?? "ceil",
     }),
   )
-  return Atomic.make((rounded.value * 10n ** BigInt(unit.decimals - rounded.scale)).toString())
+  return Atomic.make((rounded.value * 10n ** BigInt(unit.decimals - rounded.scale)).toString(), { disableChecks: true })
 }
 
 export const fromAtomic = (atomic: typeof Atomic.Type, unit: AtomicUnit): typeof Amount.Type =>
-  Amount.make(BigDecimal.make(BigInt(atomic), unit.decimals))
+  Amount.make(BigDecimal.make(BigInt(atomic), unit.decimals), { disableChecks: true })
 
 export const atomic = (unit: AtomicUnit) =>
   Atomic.pipe(
     S.decodeTo(Amount, {
       decode: SchemaGetter.transform((value) => fromAtomic(value, unit)),
-      encode: SchemaGetter.transform((value) => toAtomic(Amount.make(value), unit)),
+      encode: SchemaGetter.transform((value) => toAtomic(Amount.make(value, { disableChecks: true }), unit)),
     }),
   )
 

--- a/crosshatch/Cli/profile_add.ts
+++ b/crosshatch/Cli/profile_add.ts
@@ -68,7 +68,7 @@ export const profileAdd = Command.make("add", {
           payload: {
             amount,
             provider: "Coinbase",
-            recipient: CaAccountId.make(`eip155:8453:${address}`),
+            recipient: CaAccountId.make(`eip155:8453:${address}`, { disableChecks: true }),
           },
         })
         yield* Console.log(onrampUrl)

--- a/crosshatch/Crypto/Cek.ts
+++ b/crosshatch/Crypto/Cek.ts
@@ -15,7 +15,7 @@ export const fromBytes = (bytes: Uint8Array, config?: { readonly extractable?: b
       "encrypt",
       "decrypt",
     ]),
-  ).pipe(Effect.map((v) => Cek.make(v)))
+  ).pipe(Effect.map((v) => Cek.make(v, { disableChecks: true })))
 
 export const toBytes = (cek: typeof Cek.Type) => CryptoKey.toBytes(cek)
 
@@ -44,7 +44,7 @@ export const fromPrf = Effect.fnUntraced(function* (
       config?.extractable ?? false,
       ["encrypt", "decrypt"],
     ),
-  ).pipe(Effect.map((v) => Cek.make(v)))
+  ).pipe(Effect.map((v) => Cek.make(v, { disableChecks: true })))
 })
 
 export const encrypt = Effect.fnUntraced(function* (cek: typeof Cek.Type, value: Uint8Array) {

--- a/crosshatch/Crypto/Ed25519Pair.ts
+++ b/crosshatch/Crypto/Ed25519Pair.ts
@@ -21,10 +21,13 @@ export const Ed25519Pair = Object.assign(
 )
 
 export const fromNative = ({ privateKey, publicKey }: CryptoKeyPair) =>
-  Ed25519Pair.make({
-    privateKey: Ed25519PrivateKey.Ed25519PrivateKey.make(privateKey),
-    publicKey: Ed25519PublicKey.Ed25519PublicKey.make(publicKey),
-  })
+  Ed25519Pair.make(
+    {
+      privateKey: Ed25519PrivateKey.Ed25519PrivateKey.make(privateKey, { disableChecks: true }),
+      publicKey: Ed25519PublicKey.Ed25519PublicKey.make(publicKey, { disableChecks: true }),
+    },
+    { disableChecks: true },
+  )
 
 export const random = (config?: { readonly extractable?: boolean | undefined }) =>
   Effect.promise(() =>
@@ -42,7 +45,7 @@ export const fromSeed = (bytes: Uint8Array) =>
           ]),
         ),
       ),
-      Effect.map((v) => Ed25519PublicKey.Ed25519PublicKey.make(v)),
+      Effect.map((v) => Ed25519PublicKey.Ed25519PublicKey.make(v, { disableChecks: true })),
     ),
     privateKey: Ed25519PrivateKey.fromSeed(bytes),
-  }).pipe(Effect.map((v) => Ed25519Pair.make(v)))
+  }).pipe(Effect.map((v) => Ed25519Pair.make(v, { disableChecks: true })))

--- a/crosshatch/Crypto/Ed25519PrivateKey.ts
+++ b/crosshatch/Crypto/Ed25519PrivateKey.ts
@@ -15,7 +15,7 @@ export const fromSeed = (bytes: Uint8Array, config?: { readonly extractable?: bo
   pkcs8.set(bytes, ED25519_PKCS8_PREFIX.length)
   return Effect.promise(() =>
     crypto.subtle.importKey("pkcs8", pkcs8, { name: "Ed25519" }, config?.extractable ?? false, ["sign"]),
-  ).pipe(Effect.map((v) => Ed25519PrivateKey.make(v)))
+  ).pipe(Effect.map((v) => Ed25519PrivateKey.make(v, { disableChecks: true })))
 }
 
 export const toPkcs8 = (privateKey: typeof Ed25519PrivateKey.Type) =>
@@ -23,7 +23,7 @@ export const toPkcs8 = (privateKey: typeof Ed25519PrivateKey.Type) =>
 
 export const fromPkcs8 = (value: Uint8Array) =>
   Effect.promise(() => crypto.subtle.importKey("pkcs8", value.slice(), { name: "Ed25519" }, false, ["sign"])).pipe(
-    Effect.map(Ed25519PrivateKey.make),
+    Effect.map((v) => Ed25519PrivateKey.make(v, { disableChecks: true })),
   )
 
 export const sign = (privateKey: typeof Ed25519PrivateKey.Type, data: Uint8Array) =>

--- a/crosshatch/Crypto/Ed25519PublicKey.ts
+++ b/crosshatch/Crypto/Ed25519PublicKey.ts
@@ -6,7 +6,7 @@ export const Ed25519PublicKey = CryptoKey.CryptoKey.pipe(S.brand("crosshatch/Ed2
 
 export const fromBytes = (raw: Uint8Array) =>
   Effect.promise(() => crypto.subtle.importKey("raw", raw.slice(), { name: "Ed25519" }, true, ["verify"])).pipe(
-    Effect.map((v) => Ed25519PublicKey.make(v)),
+    Effect.map((v) => Ed25519PublicKey.make(v, { disableChecks: true })),
   )
 
 export const verify = (verifier: typeof Ed25519PublicKey.Type, signature: Uint8Array, data: Uint8Array) =>

--- a/crosshatch/Crypto/X25519Pair.ts
+++ b/crosshatch/Crypto/X25519Pair.ts
@@ -21,10 +21,13 @@ export const X25519Pair = Object.assign(
 )
 
 export const fromNative = ({ privateKey, publicKey }: CryptoKeyPair) =>
-  X25519Pair.make({
-    privateKey: X25519PrivateKey.make(privateKey),
-    publicKey: X25519PublicKey.make(publicKey),
-  })
+  X25519Pair.make(
+    {
+      privateKey: X25519PrivateKey.make(privateKey, { disableChecks: true }),
+      publicKey: X25519PublicKey.make(publicKey, { disableChecks: true }),
+    },
+    { disableChecks: true },
+  )
 
 export const random = (config?: { readonly extractable?: boolean | undefined }) =>
   Effect.promise(

--- a/crosshatch/Crypto/X25519PrivateKey.ts
+++ b/crosshatch/Crypto/X25519PrivateKey.ts
@@ -32,4 +32,4 @@ export const toPkcs8 = (privateKey: typeof X25519PrivateKey.Type) =>
 export const fromPkcs8 = (value: Uint8Array) =>
   Effect.promise(() =>
     crypto.subtle.importKey("pkcs8", value.slice(), { name: "X25519" }, false, ["deriveKey", "deriveBits"]),
-  ).pipe(Effect.map((v) => X25519PrivateKey.make(v)))
+  ).pipe(Effect.map((v) => X25519PrivateKey.make(v, { disableChecks: true })))

--- a/crosshatch/Crypto/X25519PublicKey.ts
+++ b/crosshatch/Crypto/X25519PublicKey.ts
@@ -35,5 +35,5 @@ export const encrypt = Effect.fnUntraced(function* (publicKey: typeof X25519Publ
 
 export const fromBytes = (raw: Uint8Array) =>
   Effect.promise(() => crypto.subtle.importKey("raw", raw.slice(), { name: "X25519" }, true, [])).pipe(
-    Effect.map((v) => X25519PublicKey.make(v)),
+    Effect.map((v) => X25519PublicKey.make(v, { disableChecks: true })),
   )

--- a/crosshatch/Eip155/Eip155Address.ts
+++ b/crosshatch/Eip155/Eip155Address.ts
@@ -15,5 +15,5 @@ export const fromMnemonic = (mnemonic: Mnemonic.Mnemonic): typeof Eip155Address.
   const root = HdKey.fromSeed(seed)
   const { privateKey } = root.derive("m/44'/60'/0'/0/0")
   const publicKey = Secp256k1.getPublicKey({ privateKey })
-  return Eip155Address.make(OxAddress.fromPublicKey(publicKey))
+  return Eip155Address.make(OxAddress.fromPublicKey(publicKey), { disableChecks: true })
 }

--- a/crosshatch/Extensions/PaymentId.ts
+++ b/crosshatch/Extensions/PaymentId.ts
@@ -6,7 +6,7 @@ export const PaymentId = S.String.check(S.isLengthBetween(16, 128), S.isPattern(
   S.brand("crosshatch/PaymentId"),
 )
 
-export const random = () => PaymentId.make(crypto.randomUUID())
+export const random = () => PaymentId.make(crypto.randomUUID(), { disableChecks: true })
 
 const identifier = "payment-identifier" as const
 

--- a/crosshatch/KnownAssets/Usd/MEGAUSDC.ts
+++ b/crosshatch/KnownAssets/Usd/MEGAUSDC.ts
@@ -3,7 +3,7 @@ import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.t
 
 export const eip155 = {
   4326: {
-    asset: Eip155Asset.Eip155Asset.make("0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7"),
+    asset: Eip155Asset.Eip155Asset.make("0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7", { disableChecks: true }),
     decimals: 18,
     name: "MegaUSD",
     version: "1",

--- a/crosshatch/KnownAssets/Usd/MUSD.ts
+++ b/crosshatch/KnownAssets/Usd/MUSD.ts
@@ -3,7 +3,7 @@ import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.t
 
 export const eip155 = {
   31612: {
-    asset: Eip155Asset.Eip155Asset.make("0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186"),
+    asset: Eip155Asset.Eip155Asset.make("0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186", { disableChecks: true }),
     decimals: 18,
     name: "Mezo USD",
     version: "1",

--- a/crosshatch/KnownAssets/Usd/SBC.ts
+++ b/crosshatch/KnownAssets/Usd/SBC.ts
@@ -3,7 +3,7 @@ import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.t
 
 export const eip155 = {
   723487: {
-    asset: Eip155Asset.Eip155Asset.make("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb"),
+    asset: Eip155Asset.Eip155Asset.make("0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb", { disableChecks: true }),
     decimals: 6,
     name: "Stable Coin",
     version: "1",

--- a/crosshatch/KnownAssets/Usd/USDC.ts
+++ b/crosshatch/KnownAssets/Usd/USDC.ts
@@ -4,35 +4,35 @@ import { SolanaAsset, SolanaScheme, SolanaAddress } from "../../Solana/Solana.ts
 
 export const eip155 = {
   50: {
-    asset: Eip155Asset.Eip155Asset.make("0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1"),
+    asset: Eip155Asset.Eip155Asset.make("0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1", { disableChecks: true }),
     decimals: 6,
     name: "USDC",
     version: "2",
     schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
   },
   137: {
-    asset: Eip155Asset.Eip155Asset.make("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359"),
+    asset: Eip155Asset.Eip155Asset.make("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", { disableChecks: true }),
     decimals: 6,
     name: "USD Coin",
     version: "2",
     schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
   },
   143: {
-    asset: Eip155Asset.Eip155Asset.make("0x754704Bc059F8C67012fEd69BC8A327a5aafb603"),
+    asset: Eip155Asset.Eip155Asset.make("0x754704Bc059F8C67012fEd69BC8A327a5aafb603", { disableChecks: true }),
     decimals: 6,
     name: "USD Coin",
     version: "2",
     schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
   },
   8453: {
-    asset: Eip155Asset.Eip155Asset.make("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
+    asset: Eip155Asset.Eip155Asset.make("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", { disableChecks: true }),
     decimals: 6,
     name: "USD Coin",
     version: "2",
     schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
   },
   42161: {
-    asset: Eip155Asset.Eip155Asset.make("0xaf88d065e77c8cC2239327C5EDb3A432268e5831"),
+    asset: Eip155Asset.Eip155Asset.make("0xaf88d065e77c8cC2239327C5EDb3A432268e5831", { disableChecks: true }),
     decimals: 6,
     name: "USD Coin",
     version: "2",
@@ -42,13 +42,15 @@ export const eip155 = {
 
 export const solana = {
   "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-    asset: SolanaAsset.SolanaAsset.make("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+    asset: SolanaAsset.SolanaAsset.make("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", { disableChecks: true }),
     decimals: 6,
     name: "USD Coin",
     version: "1",
     schemes: [SolanaScheme.SolanaScheme],
     metadata: {
-      tokenProgramId: SolanaAddress.SolanaAddress.make("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"),
+      tokenProgramId: SolanaAddress.SolanaAddress.make("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", {
+        disableChecks: true,
+      }),
     },
   },
 } satisfies References

--- a/crosshatch/KnownAssets/Usd/USDCE.ts
+++ b/crosshatch/KnownAssets/Usd/USDCE.ts
@@ -3,14 +3,14 @@ import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.t
 
 export const eip155 = {
   36900: {
-    asset: Eip155Asset.Eip155Asset.make("0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2"),
+    asset: Eip155Asset.Eip155Asset.make("0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2", { disableChecks: true }),
     decimals: 6,
     name: "USDC.e",
     version: "2",
     schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
   },
   190415: {
-    asset: Eip155Asset.Eip155Asset.make("0x401eCb1D350407f13ba348573E5630B83638E30D"),
+    asset: Eip155Asset.Eip155Asset.make("0x401eCb1D350407f13ba348573E5630B83638E30D", { disableChecks: true }),
     decimals: 6,
     name: "Bridged USDC",
     version: "2",

--- a/crosshatch/KnownAssets/Usd/USDT0.ts
+++ b/crosshatch/KnownAssets/Usd/USDT0.ts
@@ -3,7 +3,7 @@ import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.t
 
 export const eip155 = {
   988: {
-    asset: Eip155Asset.Eip155Asset.make("0x779Ded0c9e1022225f8E0630b35a9b54bE713736"),
+    asset: Eip155Asset.Eip155Asset.make("0x779Ded0c9e1022225f8E0630b35a9b54bE713736", { disableChecks: true }),
     decimals: 6,
     name: "USDT0",
     version: "1",

--- a/crosshatch/Mnemonic.ts
+++ b/crosshatch/Mnemonic.ts
@@ -24,6 +24,8 @@ export const env = fromConfig(Config.string("MNEMONIC"))
 
 export const layerEnv = Layer.effect(Mnemonic, env)
 
-export const random = Effect.sync(() => fromText(OxMnemonic.random(OxMnemonic.english)))
+export const random = Effect.sync(() =>
+  Redacted.make(MnemonicText.make(OxMnemonic.random(OxMnemonic.english), { disableChecks: true })),
+)
 
 export const layerRandom = Layer.effect(Mnemonic, random)

--- a/crosshatch/Requirements.ts
+++ b/crosshatch/Requirements.ts
@@ -51,9 +51,9 @@ export const logical = Effect.fnUntraced(function* <A extends LogicalAsset>(
             return payTo
               ? acc.concat({
                   amount: Amount.toAtomic(nominal, physical),
-                  asset: Asset.make(physical.asset),
+                  asset: Asset.make(physical.asset, { disableChecks: true }),
                   maxTimeoutSeconds,
-                  network: ChainId.make(`${namespace}:${reference}`),
+                  network: ChainId.make(`${namespace}:${reference}`, { disableChecks: true }),
                   payTo,
                   scheme: "exact",
                   extra: { name, version },

--- a/crosshatch/Solana/SolanaAddress.ts
+++ b/crosshatch/Solana/SolanaAddress.ts
@@ -14,5 +14,5 @@ export const fromMnemonic = (
   Slip10.derive(OxMnemonic.toSeed(Redacted.value(mnemonic)), [44, 501, 0, 0]).pipe(
     Effect.flatMap(({ privateKeySeed }) => Ed25519Pair.fromSeed(privateKeySeed)),
     Effect.flatMap(({ publicKey }) => CryptoKey.toBytes(publicKey)),
-    Effect.map(flow(Base58.fromBytes, (v) => SolanaAddress.make(v))),
+    Effect.map(flow(Base58.fromBytes, (v) => SolanaAddress.make(v, { disableChecks: true }))),
   )


### PR DESCRIPTION
Adds { disableChecks: true } to trusted internal schema construction sites, avoiding redundant runtime validation for values derived from prior checks, crypto APIs, deterministic formatting, or package-owned constants. External/boundary schema validation remains intact.