### PR TITLE
ensure payload acceptability

### DIFF
--- a/.changeset/small-papers-notice.md
+++ b/.changeset/small-papers-notice.md
@@ -1,0 +1,5 @@
+---
+"crosshatch": patch
+---
+
+Add `Payload.isAcceptable` guard.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ export default class Merchant extends Cloudflare.Worker<Merchant>()(
       "/paid",
       Effect.gen(function* () {
         const payload = yield* Payload.Payload
-        if (!payload) {
+        const accepted = yield* Requirements.denomination(KnownAssets.Usd, {
+          amount: 0.01,
+          recipients: { eip155: { 8453: yield* recipient } },
+        })
+        if (!Payload.isAcceptable(accepted, payload)) {
           const required = yield* Required.make`
           |
           | Description of the charge here.
@@ -82,15 +86,8 @@ export default class Merchant extends Cloudflare.Worker<Merchant>()(
           | What is this charge for?
           |
           | How does it fit into the current flow?
-          |
-          `.pipe(
-            Required.accept(
-              Requirements.denomination(KnownAssets.Usd, {
-                amount: 0.01,
-                recipients: { eip155: { 8453: yield* recipient } },
-              }),
-            ),
-          )
+            |
+            `.pipe(Required.accept(accepted))
           return yield* ChxHttp.require({ required })
         }
         const settlement = yield* Facilitator.settle({ payload })

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ export default class Merchant extends Cloudflare.Worker<Merchant>()(
           | What is this charge for?
           |
           | How does it fit into the current flow?
-            |
-            `.pipe(Required.accept(accepted))
+          |
+          `.pipe(Required.accept(accepted))
           return yield* ChxHttp.require({ required })
         }
         const settlement = yield* Facilitator.settle({ payload })

--- a/crosshatch/ChxRpc/ChxRpc.ts
+++ b/crosshatch/ChxRpc/ChxRpc.ts
@@ -32,7 +32,7 @@ export const layer = Layer.mergeAll(
         createTrace: (config) => PubSub.publish(events, { _tag: "CreateTrace", config }),
         propose: Effect.fnUntraced(function* (proposal) {
           const { id } = yield* FromMerchant.decodeRequired(proposal.required)
-          yield* invoices.add(id)
+          yield* invoices.add(proposal.required.accepts, id)
           yield* PubSub.publish(events, { _tag: "Propose", proposal })
           const payload = yield* invoices.await(id)
           return { payload }

--- a/crosshatch/Extensions/Invoices.ts
+++ b/crosshatch/Extensions/Invoices.ts
@@ -1,38 +1,52 @@
-import { Cause, Context, Deferred, Effect, Layer } from "effect"
+import { Cause, Context, Data, Deferred, Effect, Layer } from "effect"
 
 import * as Payload from "../Payload.ts"
+import type { Requirements } from "../Requirements.ts"
 import type { PaymentId } from "./PaymentId.ts"
+
+export class PayloadUnacceptableError extends Data.TaggedError("PayloadUnacceptableError")<{
+  readonly accepts: ReadonlyArray<Requirements>
+}> {}
 
 export class Invoices extends Context.Service<
   Invoices,
   {
-    readonly add: (id: typeof PaymentId.Type) => Effect.Effect<void>
+    readonly add: (accepts: ReadonlyArray<Requirements>, id: typeof PaymentId.Type) => Effect.Effect<void>
 
     readonly await: (id: typeof PaymentId.Type) => Effect.Effect<Payload.Payload, Cause.NoSuchElementError>
 
     readonly resolve: (
       id: typeof PaymentId.Type,
       payload: Payload.Payload,
-    ) => Effect.Effect<void, Cause.NoSuchElementError>
+    ) => Effect.Effect<void, Cause.NoSuchElementError | PayloadUnacceptableError>
   }
 >()("crosshatch/ChxRpc/Invoices") {}
 
 export const layerMemory = Layer.effect(
   Invoices,
   Effect.sync(() => {
-    const invoices: Record<typeof PaymentId.Type, Deferred.Deferred<Payload.Payload>> = {}
+    const invoices: Record<
+      typeof PaymentId.Type,
+      {
+        readonly accepts: ReadonlyArray<Requirements>
+        readonly deferred: Deferred.Deferred<Payload.Payload>
+      }
+    > = {}
     return {
-      add: Effect.fnUntraced(function* (id) {
+      add: Effect.fnUntraced(function* (accepts, id) {
         const deferred = yield* Deferred.make<Payload.Payload>()
-        invoices[id] = deferred
+        invoices[id] = { accepts, deferred }
       }),
       await: Effect.fnUntraced(function* (paymentId) {
-        const invoice = yield* Effect.fromNullishOr(invoices[paymentId])
-        return yield* Deferred.await(invoice)
+        const { deferred } = yield* Effect.fromNullishOr(invoices[paymentId])
+        return yield* Deferred.await(deferred)
       }),
       resolve: Effect.fnUntraced(function* (id, payload) {
-        const deferred = yield* Effect.fromNullishOr(invoices[id])
-        delete invoices[id]
+        const { deferred, accepts } = yield* Effect.fromNullishOr(invoices[id])
+        if (!Payload.isAcceptable(accepts, payload)) {
+          delete invoices[id]
+          return yield* new PayloadUnacceptableError({ accepts })
+        }
         return yield* Deferred.succeed(deferred, payload)
       }),
     }

--- a/crosshatch/Payload.ts
+++ b/crosshatch/Payload.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Schema as S } from "effect"
+import { Context, Effect, Equal, Schema as S } from "effect"
 
 import { JsonRecord } from "./_util.ts"
 import { Payer } from "./Payer.ts"
@@ -26,9 +26,18 @@ export const Payload = Object.assign(
   }),
 )
 
+export type Acceptable = typeof Acceptable.Type
+export const Acceptable = Payload.pipe(S.brand("crosshatch/Acceptable"))
+
 export const PayloadFromBase64JsonString = S.StringFromBase64.pipe(S.decodeTo(S.fromJsonString(S.toCodecJson(Payload))))
 
 export const make = Effect.fnUntraced(function* ({ required }: { readonly required: Required }) {
   const { createPayload } = yield* Payer
   return yield* createPayload({ required })
 })
+
+export const isAcceptable = (
+  requirements: ReadonlyArray<Requirements>,
+  payload: Payload | undefined,
+): payload is Acceptable =>
+  payload !== undefined && requirements.some((requirement) => Equal.equals(requirement, payload.accepted))

--- a/crosshatch/Payload.ts
+++ b/crosshatch/Payload.ts
@@ -37,7 +37,7 @@ export const make = Effect.fnUntraced(function* ({ required }: { readonly requir
 })
 
 export const isAcceptable = (
-  requirements: ReadonlyArray<Requirements>,
+  accepts: ReadonlyArray<Requirements>,
   payload: Payload | undefined,
 ): payload is Acceptable =>
-  payload !== undefined && requirements.some((requirement) => Equal.equals(requirement, payload.accepted))
+  payload !== undefined && accepts.some((requirement) => Equal.equals(requirement, payload.accepted))

--- a/docs/src/pages/facilitation.mdx
+++ b/docs/src/pages/facilitation.mdx
@@ -63,14 +63,17 @@ Most merchant servers provide the facilitator client at the application layer so
 every paid route settles against the same service.
 
 ```ts
-import { Facilitator, Payload } from "crosshatch"
+import { Facilitator, Payload, Required } from "crosshatch"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 
+declare const required: Required.Required
+
 const route = Effect.gen(function* () {
-  const payload = yield* Payload.Payload.pipe(
-    Effect.flatMap(Effect.fromNullishOr),
-  )
+  const payload = yield* Payload.Payload
+  if (!Payload.isAcceptable(required.accepts, payload)) {
+    return required
+  }
   const settlement = yield* Facilitator.settle({ payload })
   // ...
 }).pipe(

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -153,15 +153,14 @@ const router = HttpRouter.add(
   "/paid",
   Effect.gen(function* () {
     const payload = yield* Payload.Payload
-    if (!payload) {
+    const accepted = yield* Requirements.logical(KnownAssets.Usd.USDC, {
+      amount: 0.01,
+      recipients: { eip155: { 8453: yield* recipient } },
+    })
+    if (!Payload.isAcceptable(accepted, payload)) {
       const required =
         yield* Required.make`Description of the charge here.`.pipe(
-          Required.accept(
-            Requirements.logical(KnownAssets.Usd.USDC, {
-              amount: 0.01,
-              recipients: { eip155: { 8453: yield* recipient } },
-            }),
-          ),
+          Required.accept(accepted),
         )
       return yield* ChxHttp.require({ required }).pipe(
         Effect.map(HttpServerResponse.setStatus(402)),

--- a/docs/src/pages/payload.mdx
+++ b/docs/src/pages/payload.mdx
@@ -56,6 +56,26 @@ const program = Effect.gen(function* () {
 payload may need to select a supported requirement, read wallet configuration,
 sign typed data, and encode chain-specific payload fields.
 
+## Checking A Payload
+
+Decoding a payload only confirms its shape. Before verification or settlement,
+use `Payload.isAcceptable` to confirm that it selected one of the requirements
+offered for the resource.
+
+```ts
+import { Payload, Required } from "crosshatch"
+
+declare const required: Required.Required
+declare const payload: Payload.Payload | undefined
+
+if (Payload.isAcceptable(required.accepts, payload)) {
+  // payload is present and its accepted requirement matches the invoice
+}
+```
+
+The check also narrows the value to `Payload.Acceptable`, so downstream code can
+require evidence that the comparison was performed.
+
 ## The `Payer` Requirement
 
 `Payload.make` does not know which wallet, account, chain, or

--- a/docs/src/pages/quickstart/for-merchants.mdx
+++ b/docs/src/pages/quickstart/for-merchants.mdx
@@ -21,8 +21,9 @@ or shared pot of funds that receives revenue.
 ## Protect a Route
 
 Declare what the resource costs and return a 402 response when the request does
-not include a payment payload. This example uses HTTP, but Crosshatch is not
-limited to HTTP; route protection is just one integration path.
+not include a payment payload that selects one of those requirements. This
+example uses HTTP, but Crosshatch is not limited to HTTP; route protection is
+just one integration path.
 
 ```ts
 import {
@@ -42,17 +43,16 @@ const route = Effect.gen(function* () {
     "PAY_TO_EIP155",
   )
   const payload = yield* Payload.Payload
+  const accepted = yield* Requirements.logical(KnownAssets.Usd.USDC, {
+    amount: 0.01,
+    recipients: {
+      eip155: { 8453: recipient },
+    },
+  })
 
-  if (!payload) {
+  if (!Payload.isAcceptable(accepted, payload)) {
     const required = yield* Required.make`Access to the paid resource.`.pipe(
-      Required.accept(
-        Requirements.logical(KnownAssets.Usd.USDC, {
-          amount: 0.01,
-          recipients: {
-            eip155: { 8453: recipient },
-          },
-        }),
-      ),
+      Required.accept(accepted),
     )
 
     return yield* ChxHttp.require({ required }).pipe(
@@ -87,7 +87,8 @@ flow:
 - Parse an incoming payment payload from the request headers.
 - Make the parsed payload available as an Effect service.
 - Return an x402 payment-required response when no payload was supplied.
-- Settle the supplied payload before returning the paid resource.
+- Confirm the payload selects an accepted requirement, then settle it before
+  returning the paid resource.
 
 Use this integration when your merchant service is built with
 `effect/unstable/http`.
@@ -107,13 +108,15 @@ const app = ChxHttp.layerMiddleware().pipe(HttpRouter.toHttpEffect)
 
 If the header is absent or cannot be decoded, the provided payload is
 `undefined`. Your route can then decide whether to return a payment requirement
-or continue with unpaid behavior.
+or continue with unpaid behavior. A successfully decoded payload is not
+necessarily acceptable for that route; compare it with the offered requirements
+using `Payload.isAcceptable` before verification or settlement.
 
 ### Protect An Effect HTTP Route
 
-Inside the route, read the parsed payload service. If there is no payload, build
-a `Required` value and return `ChxHttp.require({ required })` with its status
-set to `402`.
+Inside the route, read the parsed payload service. If it is absent or does not
+match one of the route's accepted requirements, build a `Required` value and
+return `ChxHttp.require({ required })` with its status set to `402`.
 
 ```ts
 import {
@@ -129,22 +132,21 @@ import { HttpServerResponse } from "effect/unstable/http"
 
 const paidRoute = Effect.gen(function* () {
   const payload = yield* Payload.Payload
+  const accepted = yield* Requirements.logical(KnownAssets.Usd.USDC, {
+    amount: 0.01,
+    recipients: {
+      eip155: {
+        8453: yield* Config.schema(
+          Eip155Address.Eip155Address,
+          "PAY_TO_EIP155",
+        ),
+      },
+    },
+  })
 
-  if (!payload) {
+  if (!Payload.isAcceptable(accepted, payload)) {
     const required = yield* Required.make`Access to the paid resource.`.pipe(
-      Required.accept(
-        Requirements.logical(KnownAssets.Usd.USDC, {
-          amount: 0.01,
-          recipients: {
-            eip155: {
-              8453: yield* Config.schema(
-                Eip155Address.Eip155Address,
-                "PAY_TO_EIP155",
-              ),
-            },
-          },
-        }),
-      ),
+      Required.accept(accepted),
     )
 
     return yield* ChxHttp.require({ required }).pipe(
@@ -176,7 +178,7 @@ declare const required: Required.Required
 const paidRoute = Effect.gen(function* () {
   const payload = yield* Payload.Payload
 
-  if (!payload) {
+  if (!Payload.isAcceptable(required.accepts, payload)) {
     return yield* ChxHttp.require({ required }).pipe(
       Effect.map(HttpServerResponse.setStatus(402)),
     )
@@ -211,7 +213,7 @@ declare const required: Required.Required
 const paidRoute = Effect.gen(function* () {
   const payload = yield* Payload.Payload
 
-  if (!payload) {
+  if (!Payload.isAcceptable(required.accepts, payload)) {
     return yield* ChxHttp.require({ required }).pipe(
       Effect.map(HttpServerResponse.setStatus(402)),
     )

--- a/examples/effect-http/ExampleEffectHttp.ts
+++ b/examples/effect-http/ExampleEffectHttp.ts
@@ -29,7 +29,11 @@ export default class ExampleEffectHttp extends Cloudflare.Worker<ExampleEffectHt
       "/paid",
       Effect.gen(function* () {
         const payload = yield* Payload.Payload
-        if (!payload) {
+        const accepted = yield* Requirements.denomination(KnownAssets.Usd, {
+          amount: 0.01,
+          recipients: { eip155: { 8453: recipient } },
+        })
+        if (!Payload.isAcceptable(accepted, payload)) {
           const required = yield* Required.make`
           |
           | Description of the charge here.
@@ -43,12 +47,7 @@ export default class ExampleEffectHttp extends Cloudflare.Worker<ExampleEffectHt
               required: true,
               id: PaymentId.random(),
             }),
-            Required.accept(
-              Requirements.denomination(KnownAssets.Usd, {
-                amount: 0.01,
-                recipients: { eip155: { 8453: recipient } },
-              }),
-            ),
+            Required.accept(accepted),
           )
           return yield* ChxHttp.require({ required })
         }


### PR DESCRIPTION
Adds `Payload.isAcceptable` to ensure submitted payment payloads select one of a resource’s accepted requirements before verification or settlement.

```ts
if (!Payload.isAcceptable(required.accepts, payload)) {
  return yield* ChxHttp.require({ required })
}
```