### PR TITLE
add currencies, improve Permit2, standardize layer naming

### DIFF
--- a/.changeset/upset-doodles-lead.md
+++ b/.changeset/upset-doodles-lead.md
@@ -1,0 +1,10 @@
+---
+"@crosshatch/util": patch
+"crosshatch": patch
+"@crosshatch/alchemy": patch
+"@crosshatch/widget": patch
+---
+
+Add EURC, JPYC, and XSGD currency support, improve Permit2 authorization
+generation, and standardize layer naming across the API, documentation, and
+examples.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -26,5 +26,6 @@ jobs:
           publish: pnpm changeset publish
           commit: version packages
           title: version packages
+          prDraft: create
         env:
           GITHUB_TOKEN: ${{ secrets.MADHATCHER_PAT }}

--- a/@crosshatch/util/schema.ts
+++ b/@crosshatch/util/schema.ts
@@ -1,7 +1,0 @@
-import { Schema as S, flow } from "effect"
-
-export type TopFromString = S.Codec<any, string, any, any>
-
-const toJsonStringCodec = flow(S.toCodecJson, S.fromJsonString)
-export const encodeJsonString = flow(toJsonStringCodec, S.encodeEffect)
-export const decodeJsonString = flow(toJsonStringCodec, S.decodeUnknownEffect)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ import { ChxHttp } from "crosshatch"
 import { Console, Effect, Layer } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 
-import { PayerLive } from "./PayerLive.ts"
+import { layerPayer } from "./layerPayer.ts"
 
-const BlockrunLive = OpenAiLanguageModel.layer({
+const layerLanguageModelBlockrun = OpenAiLanguageModel.layer({
   model: "deepseek/deepseek-chat",
 }).pipe(
   Layer.provide(
     OpenAiClient.layer({ apiUrl: "https://blockrun.ai/api/v1" }).pipe(
-      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))),
+      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayer))),
     ),
   ),
 )
@@ -35,12 +35,12 @@ LanguageModel.generateText({
   prompt: "Hello from Crosshatch.",
 }).pipe(
   Effect.tap(({ text }) => Console.log(text)),
-  Effect.provide(BlockrunLive),
+  Effect.provide(layerLanguageModelBlockrun),
   Effect.runFork,
 )
 ```
 
-> Payment capability––`PayerLive`--detailed below.
+> Payment capability––`layerPayer`--detailed below.
 
 ## Example Merchant
 
@@ -121,7 +121,7 @@ The following allows the signing payment payloads for various USD-denominated
 stablecoins across EVM and Solana chains. Payment capability derived from a
 single mnemonic `MNEMONIC` in the environment variables.
 
-`PayerLive.ts`
+`layerPayer.ts`
 
 ```ts
 import { Accept, Known, Mnemonic, Payer } from "crosshatch"
@@ -129,24 +129,24 @@ import { Erc3009Scheme, Eip155Signer, Permit2Scheme } from "crosshatch/Eip155"
 import { SolanaState, SolanaScheme, SolanaSigner } from "crosshatch/Solana"
 import { Config, Layer } from "effect"
 
-const SolanaStateLive = Config.string("SOLANA_RPC_URL").pipe(
+const layerSolanaStateFromConfig = Config.string("SOLANA_RPC_URL").pipe(
   Config.map(SolanaState.layer),
   Layer.unwrap,
 )
 
-const SchemesLive = Layer.mergeAll(
+const layerSchemes = Layer.mergeAll(
   Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(
-    Layer.provide(Eip155Signer.layerMnemonic),
+    Layer.provide(Eip155Signer.layerFromMnemonic),
   ),
   SolanaScheme.layer.pipe(
-    Layer.provide([SolanaSigner.layerMnemonic, SolanaStateLive]),
+    Layer.provide([SolanaSigner.layerFromMnemonic, layerSolanaStateFromConfig]),
   ),
 )
 
-export const PayerLive = Payer.layerLocal({
+export const layerPayer = Payer.layerLocal({
   accept: Accept.first(Known),
-  schemes: SchemesLive,
-}).pipe(Layer.provide(Mnemonic.layerEnv))
+  schemes: layerSchemes,
+}).pipe(Layer.provide(Mnemonic.layerFromEnv))
 ```
 
 ## Contributing

--- a/crosshatch/Browser/BrowserServices.ts
+++ b/crosshatch/Browser/BrowserServices.ts
@@ -6,7 +6,7 @@ import { FacadeClient } from "./Facade/FacadeClient.ts"
 import * as FacadePrelude from "./Facade/FacadePrelude.ts"
 import { PrerequisitesWidget } from "./Widgets.ts"
 
-const BridgeLive = Layer.effect(
+const layerBridge = Layer.effect(
   Bridge,
   Effect.gen(function* () {
     const facade = yield* FacadeClient
@@ -31,4 +31,7 @@ const BridgeLive = Layer.effect(
   }),
 )
 
-export const layer = Payer.layerBridge.pipe(Layer.provideMerge(BridgeLive), Layer.provideMerge(FacadePrelude.layer))
+export const layer = Payer.layerFromBridge.pipe(
+  Layer.provideMerge(layerBridge),
+  Layer.provideMerge(FacadePrelude.layer),
+)

--- a/crosshatch/Browser/Facade/FacadePrelude.ts
+++ b/crosshatch/Browser/Facade/FacadePrelude.ts
@@ -3,7 +3,7 @@ import { Effect, Stream, Layer, SubscriptionRef, Deferred, Semaphore, flow } fro
 import { FacadeClient } from "./FacadeClient.ts"
 import { FacadeState } from "./FacadeState.ts"
 
-const FacadeStateLive = Layer.effect(
+const layerFacadeState = Layer.effect(
   FacadeState,
   Effect.gen(function* () {
     const task = yield* Semaphore.make(1).pipe(Effect.map((v) => Semaphore.withPermits(v, 1)))
@@ -28,4 +28,4 @@ const FacadeStateLive = Layer.effect(
   }),
 )
 
-export const layer = FacadeStateLive.pipe(Layer.provideMerge(FacadeClient.layer))
+export const layer = layerFacadeState.pipe(Layer.provideMerge(FacadeClient.layer))

--- a/crosshatch/ChxHttp/server.ts
+++ b/crosshatch/ChxHttp/server.ts
@@ -33,11 +33,11 @@ export const layerMiddleware = <X extends ReadonlyArray<Extension.Extension.Any>
           Option.flatMap(S.decodeUnknownOption(PayloadFromBase64JsonString)),
           Option.getOrUndefined,
         )
-        const Live = Layer.mergeAll(
+        const layerRequestServices = Layer.mergeAll(
           Layer.succeed(Payload, payload),
-          ...(config?.extensions?.map((v) => Extension.layerPayload(v, payload)) ?? []),
+          ...(config?.extensions?.map((v) => Extension.layerFromPayload(v, payload)) ?? []),
         ) as Layer.Layer<X[number] | Payload, S.SchemaError>
-        return yield* Effect.provide(effect, Live)
+        return yield* Effect.provide(effect, layerRequestServices)
       }),
     { global: true },
   )

--- a/crosshatch/Crypto/Ed25519Pair.ts
+++ b/crosshatch/Crypto/Ed25519Pair.ts
@@ -35,17 +35,20 @@ export const random = (config?: { readonly extractable?: boolean | undefined }) 
   ).pipe(Effect.map(fromNative))
 
 export const fromSeed = (bytes: Uint8Array) =>
-  Effect.all({
-    publicKey: Ed25519PrivateKey.fromSeed(bytes, { extractable: true }).pipe(
-      Effect.flatMap((v) => Effect.promise(() => crypto.subtle.exportKey("jwk", v))),
-      Effect.flatMap(({ x }) =>
-        Effect.promise(() =>
-          crypto.subtle.importKey("jwk", { crv: "Ed25519", kty: "OKP", ...(x && { x }) }, { name: "Ed25519" }, true, [
-            "verify",
-          ]),
+  Effect.all(
+    {
+      publicKey: Ed25519PrivateKey.fromSeed(bytes, { extractable: true }).pipe(
+        Effect.flatMap((v) => Effect.promise(() => crypto.subtle.exportKey("jwk", v))),
+        Effect.flatMap(({ x }) =>
+          Effect.promise(() =>
+            crypto.subtle.importKey("jwk", { crv: "Ed25519", kty: "OKP", ...(x && { x }) }, { name: "Ed25519" }, true, [
+              "verify",
+            ]),
+          ),
         ),
+        Effect.map((v) => Ed25519PublicKey.Ed25519PublicKey.make(v, { disableChecks: true })),
       ),
-      Effect.map((v) => Ed25519PublicKey.Ed25519PublicKey.make(v, { disableChecks: true })),
-    ),
-    privateKey: Ed25519PrivateKey.fromSeed(bytes),
-  }).pipe(Effect.map((v) => Ed25519Pair.make(v, { disableChecks: true })))
+      privateKey: Ed25519PrivateKey.fromSeed(bytes),
+    },
+    { concurrency: "unbounded" },
+  ).pipe(Effect.map((v) => Ed25519Pair.make(v, { disableChecks: true })))

--- a/crosshatch/Eip155/Eip155Signer.test.ts
+++ b/crosshatch/Eip155/Eip155Signer.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect"
 import { Hash, TypedData } from "ox"
 
 import * as Mnemonic from "../Mnemonic.ts"
-import { Eip155Signer, layerMnemonic } from "./Eip155Signer.ts"
+import { Eip155Signer, layerFromMnemonic } from "./Eip155Signer.ts"
 
 const mnemonicText = "test test test test test test test test test test test junk"
 
@@ -37,7 +37,7 @@ describe(import.meta.url, () => {
     "signs typed data with a recoverable deterministic signature",
     Effect.fn(function* () {
       const signer = yield* Eip155Signer.pipe(
-        Effect.provide(layerMnemonic.pipe(Layer.provide(Mnemonic.layerText(mnemonicText)))),
+        Effect.provide(layerFromMnemonic.pipe(Layer.provide(Mnemonic.layerFromText(mnemonicText)))),
       )
       expect(Hash.keccak256(TypedData.encode(typedData))).toBe(expectedHash)
       expect(signer.address).toBe(expectedAddress)

--- a/crosshatch/Eip155/Eip155Signer.ts
+++ b/crosshatch/Eip155/Eip155Signer.ts
@@ -16,7 +16,7 @@ export class Eip155Signer extends Context.Service<
   }
 >()("crosshatch/Eip155/Eip155Signer") {}
 
-export const layerMnemonic = Layer.effect(
+export const layerFromMnemonic = Layer.effect(
   Eip155Signer,
   Effect.gen(function* () {
     const mnemonic = yield* Mnemonic.Mnemonic

--- a/crosshatch/Eip155/Permit2Scheme.ts
+++ b/crosshatch/Eip155/Permit2Scheme.ts
@@ -7,7 +7,9 @@ import { Eip155Signer } from "./Eip155Signer.ts"
 
 export type Extra = typeof Extra.Type
 export const Extra = S.Struct({
-  assetTransferMethod: S.Never.pipe(S.optional),
+  assetTransferMethod: S.Literal("permit2"),
+  name: S.String.pipe(S.optional),
+  version: S.String.pipe(S.optional),
 })
 
 export class Permit2Scheme extends Scheme.Service<Permit2Scheme, void, Extra>()("crosshatch/Eip155/Permit2Scheme") {}
@@ -26,15 +28,14 @@ export interface Permit2 {
     readonly witness: {
       readonly to: string
       readonly validAfter: string
-      readonly extra?: string
     }
   }
 }
 
-const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
-const EXACT_PERMIT2_PROXY = "0x4020615294c913F045dc10f0a5cdEbd86c280001"
+export const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+export const EXACT_PERMIT2_PROXY = "0x402085c248EeA27D92E8b30b2C58ed07f9E20001"
 
-const PERMIT2_ABI_TYPES = {
+export const PERMIT2_ABI_TYPES = {
   PermitWitnessTransferFrom: [
     { name: "permitted", type: "TokenPermissions" },
     { name: "spender", type: "address" },
@@ -49,7 +50,6 @@ const PERMIT2_ABI_TYPES = {
   Witness: [
     { name: "to", type: "address" },
     { name: "validAfter", type: "uint256" },
-    { name: "extra", type: "bytes" },
   ],
 } as const
 
@@ -64,15 +64,14 @@ export const layer = Permit2Scheme.layer({ known: S.Void, extra: Extra }, () =>
     const spender = Address.from(EXACT_PERMIT2_PROXY)
     const deadline = (now + accepted.maxTimeoutSeconds).toString()
     const to = Address.from(accepted.payTo, { checksum: true })
-    const validAfter = (now - 600).toString()
-    const extra = "0x"
+    const validAfter = "0"
     const permit2Authorization: Permit2["permit2Authorization"] = {
       from: signer.address,
       permitted: { token, amount },
       spender,
       nonce,
       deadline,
-      witness: { to, validAfter, extra },
+      witness: { to, validAfter },
     }
     const signature = signer.signTypedData({
       domain: {
@@ -93,7 +92,6 @@ export const layer = Permit2Scheme.layer({ known: S.Void, extra: Extra }, () =>
         witness: {
           to,
           validAfter: BigInt(validAfter),
-          extra,
         },
       },
     })

--- a/crosshatch/Extension.ts
+++ b/crosshatch/Extension.ts
@@ -76,7 +76,7 @@ export const Service =
     })
   }
 
-export const layerPayload = <
+export const layerFromPayload = <
   Self,
   Id extends string,
   Identifier extends string,

--- a/crosshatch/Known/EUR/EUR.ts
+++ b/crosshatch/Known/EUR/EUR.ts
@@ -1,0 +1,1 @@
+export * as EURC from "./EURC.ts"

--- a/crosshatch/Known/EUR/EURC.ts
+++ b/crosshatch/Known/EUR/EURC.ts
@@ -1,0 +1,56 @@
+import type { References } from "../../Asset.ts"
+import { Eip155Asset, Erc3009Scheme, Permit2Scheme } from "../../Eip155/Eip155.ts"
+import { SolanaAsset, SolanaScheme, SolanaAddress } from "../../Solana/Solana.ts"
+
+export const eip155 = {
+  1: {
+    asset: Eip155Asset.Eip155Asset.make("0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c", { disableChecks: true }),
+    decimals: 6,
+    name: "Euro Coin",
+    version: "2",
+    schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
+  },
+  25: {
+    asset: Eip155Asset.Eip155Asset.make("0xA6dE01a2d62C6B5f3525d768f34d276652C554c8", { disableChecks: true }),
+    decimals: 6,
+    name: "EURC",
+    version: "2",
+    schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
+  },
+  480: {
+    asset: Eip155Asset.Eip155Asset.make("0x1C60ba0A0eD1019e8Eb035E6daF4155A5cE2380B", { disableChecks: true }),
+    decimals: 6,
+    name: "EURC",
+    version: "2",
+    schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
+  },
+  8453: {
+    asset: Eip155Asset.Eip155Asset.make("0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42", { disableChecks: true }),
+    decimals: 6,
+    name: "EURC",
+    version: "2",
+    schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
+  },
+  43114: {
+    asset: Eip155Asset.Eip155Asset.make("0xC891EB4cbdEFf6e073e859e987815Ed1505c2ACD", { disableChecks: true }),
+    decimals: 6,
+    name: "Euro Coin",
+    version: "2",
+    schemes: [Erc3009Scheme.Erc3009Scheme, Permit2Scheme.Permit2Scheme],
+  },
+} as const satisfies References
+
+export const solana = {
+  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+    asset: SolanaAsset.SolanaAsset.make("HzwqbKZw8HxMN6bF2yFZNrht3c2iXXzpKcFu7uBEDKtr", { disableChecks: true }),
+    decimals: 6,
+    name: "EURC",
+    version: "1",
+    schemes: [SolanaScheme.SolanaScheme],
+    metadata: {
+      tokenProgramId: SolanaAddress.SolanaAddress.make("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", {
+        disableChecks: true,
+      }),
+    },
+  },
+} as const satisfies References

--- a/crosshatch/Known/JPY/JPY.ts
+++ b/crosshatch/Known/JPY/JPY.ts
@@ -1,0 +1,1 @@
+export * as JPYC from "./JPYC.ts"

--- a/crosshatch/Known/JPY/JPYC.ts
+++ b/crosshatch/Known/JPY/JPYC.ts
@@ -1,0 +1,26 @@
+import type { References } from "../../Asset.ts"
+import { Eip155Asset, Permit2Scheme } from "../../Eip155/Eip155.ts"
+
+export const eip155 = {
+  1: {
+    asset: Eip155Asset.Eip155Asset.make("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB", { disableChecks: true }),
+    decimals: 18,
+    name: "JPY Coin",
+    version: "2",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  137: {
+    asset: Eip155Asset.Eip155Asset.make("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB", { disableChecks: true }),
+    decimals: 18,
+    name: "JPY Coin",
+    version: "2",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  43114: {
+    asset: Eip155Asset.Eip155Asset.make("0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB", { disableChecks: true }),
+    decimals: 18,
+    name: "JPY Coin",
+    version: "2",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+} as const satisfies References

--- a/crosshatch/Known/Known.ts
+++ b/crosshatch/Known/Known.ts
@@ -1,1 +1,4 @@
+export * as EUR from "./EUR/EUR.ts"
+export * as JPY from "./JPY/JPY.ts"
+export * as SGD from "./SGD/SGD.ts"
 export * as USD from "./USD/USD.ts"

--- a/crosshatch/Known/SGD/SGD.ts
+++ b/crosshatch/Known/SGD/SGD.ts
@@ -1,0 +1,1 @@
+export * as XSGD from "./XSGD.ts"

--- a/crosshatch/Known/SGD/XSGD.ts
+++ b/crosshatch/Known/SGD/XSGD.ts
@@ -1,0 +1,56 @@
+import type { References } from "../../Asset.ts"
+import { Eip155Asset, Permit2Scheme } from "../../Eip155/Eip155.ts"
+import { SolanaAsset, SolanaScheme, SolanaAddress } from "../../Solana/Solana.ts"
+
+export const eip155 = {
+  1: {
+    asset: Eip155Asset.Eip155Asset.make("0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  137: {
+    asset: Eip155Asset.Eip155Asset.make("0xDC3326e71D45186F113a2F448984CA0e8D201995", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  8453: {
+    asset: Eip155Asset.Eip155Asset.make("0x0A4C9cb2778aB3302996A34BeFCF9a8Bc288C33b", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  42161: {
+    asset: Eip155Asset.Eip155Asset.make("0xE333e7754a2DC1E020a162Ecab019254b9DaB653", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+  43114: {
+    asset: Eip155Asset.Eip155Asset.make("0xb2F85b7AB3c2b6f62DF06dE6aE7D09c010a5096E", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [Permit2Scheme.Permit2Scheme],
+  },
+} as const satisfies References
+
+export const solana = {
+  "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+    asset: SolanaAsset.SolanaAsset.make("71S9cppWipeUEQDFngYwxjoxB6Sz1MUqX72byLsVYJqy", { disableChecks: true }),
+    decimals: 6,
+    name: "XSGD",
+    version: "1",
+    schemes: [SolanaScheme.SolanaScheme],
+    metadata: {
+      tokenProgramId: SolanaAddress.SolanaAddress.make("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", {
+        disableChecks: true,
+      }),
+    },
+  },
+} as const satisfies References

--- a/crosshatch/Mnemonic.ts
+++ b/crosshatch/Mnemonic.ts
@@ -19,15 +19,15 @@ export const fromText = (text: string) => Redacted.make(MnemonicText.make(text))
 
 export const toSeed = (mnemonic: Mnemonic) => mnemonicToSeedSync(Redacted.value(mnemonic))
 
-export const layerText = flow(fromText, Layer.succeed(Mnemonic))
+export const layerFromText = flow(fromText, Layer.succeed(Mnemonic))
 
 export const fromConfig = (config: Config.Config<string>) => Config.map(config, fromText)
 
-export const layerConfig = flow(fromConfig, Layer.effect(Mnemonic))
+export const layerFromConfig = flow(fromConfig, Layer.effect(Mnemonic))
 
-export const env = fromConfig(Config.string("MNEMONIC"))
+export const fromEnv = fromConfig(Config.string("MNEMONIC"))
 
-export const layerEnv = Layer.effect(Mnemonic, env)
+export const layerFromEnv = Layer.effect(Mnemonic, fromEnv)
 
 export const random = Effect.sync(() =>
   Redacted.make(MnemonicText.make(generateMnemonic(wordlist), { disableChecks: true })),

--- a/crosshatch/Payer.ts
+++ b/crosshatch/Payer.ts
@@ -71,7 +71,7 @@ export const layerLocal = <ROut, E, RIn>({
     }),
   )
 
-export const layerBridge = Effect.map(Bridge, ({ propose }) => ({
+export const layerFromBridge = Effect.map(Bridge, ({ propose }) => ({
   createPayload: flow(
     propose,
     Effect.catchTags({

--- a/crosshatch/Requirements.ts
+++ b/crosshatch/Requirements.ts
@@ -80,6 +80,7 @@ export const denomination = <A extends Denomination>(
     readonly ttl?: Duration.Input | undefined
   },
 ) =>
-  Effect.all(Record.toEntries(denomination).map(([_k, logicalAsset]) => logical(logicalAsset, config as never))).pipe(
-    Effect.map(Array.flatten),
-  )
+  Effect.all(
+    Record.toEntries(denomination).map(([_k, logicalAsset]) => logical(logicalAsset, config as never)),
+    { concurrency: "unbounded" },
+  ).pipe(Effect.map(Array.flatten))

--- a/crosshatch/Solana/SolanaScheme.ts
+++ b/crosshatch/Solana/SolanaScheme.ts
@@ -61,7 +61,9 @@ export const layer = SolanaScheme.layer(
               mint,
             }),
           )
-        const [[sourceAta], [destAta]] = yield* Effect.all([ata(signer.address), ata(address(accepted.payTo))])
+        const [[sourceAta], [destAta]] = yield* Effect.all([ata(signer.address), ata(address(accepted.payTo))], {
+          concurrency: "unbounded",
+        })
 
         const message = solanaPipe(
           createTransactionMessage({ version: 0 }),

--- a/crosshatch/Solana/SolanaSigner.ts
+++ b/crosshatch/Solana/SolanaSigner.ts
@@ -11,7 +11,7 @@ export class SolanaSigner extends Context.Service<SolanaSigner, TransactionParti
   "crosshatch/Solana/SolanaSigner",
 ) {}
 
-export const layerMnemonic = Layer.effect(
+export const layerFromMnemonic = Layer.effect(
   SolanaSigner,
   Effect.gen(function* () {
     const mnemonic = yield* Mnemonic.Mnemonic

--- a/crosshatch/Unified/UnifiedSchemes.ts
+++ b/crosshatch/Unified/UnifiedSchemes.ts
@@ -13,13 +13,13 @@ export interface UnifiedSchemesConfig {
 
 export const layer = (config?: UnifiedSchemesConfig) => {
   return Layer.mergeAll(
-    Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(Layer.provide(Eip155Signer.layerMnemonic)),
+    Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(Layer.provide(Eip155Signer.layerFromMnemonic)),
     config?.solana
       ? (Config.isConfig(config.solana.rpc) ? config.solana.rpc : Config.succeed(config.solana.rpc)).pipe(
           Effect.map(
             UndefinedOr.match({
               onDefined: (v) =>
-                SolanaScheme.layer.pipe(Layer.provide([SolanaSigner.layerMnemonic, SolanaState.layer(v)])),
+                SolanaScheme.layer.pipe(Layer.provide([SolanaSigner.layerFromMnemonic, SolanaState.layer(v)])),
               onUndefined: () => Layer.empty,
             }),
           ),

--- a/docs/src/pages/bridge.mdx
+++ b/docs/src/pages/bridge.mdx
@@ -14,7 +14,7 @@ user-controlled approval surface.
 `Payer` is still the service that `Payload.make` and the HTTP client use to
 obtain a concrete x402 payload. The new split is that a `Payer` can either sign
 locally with a chain implementation, or be backed by a `Bridge` via
-`Payer.layerBridge`.
+`Payer.layerFromBridge`.
 
 ## Propose A Payment
 
@@ -48,14 +48,16 @@ declare const askWalletToPay: (
   proposal: Bridge.Proposal,
 ) => Effect.Effect<{ readonly payload: Payload.Payload }, Bridge.ProposeError>
 
-const BridgeLive = Layer.succeed(Bridge.Bridge, {
+const layerBridge = Layer.succeed(Bridge.Bridge, {
   propose: ({ required, traceId }) =>
     Effect.gen(function* () {
       return yield* askWalletToPay({ required, traceId })
     }),
 })
 
-const payerLayer = Payer.layerBridge.pipe(Layer.provide(BridgeLive))
+const layerPayerFromBridge = Payer.layerFromBridge.pipe(
+  Layer.provide(layerBridge),
+)
 ```
 
 Use this when the code consuming paid resources should not directly hold signing

--- a/docs/src/pages/chx-rpc.mdx
+++ b/docs/src/pages/chx-rpc.mdx
@@ -41,7 +41,7 @@ const app = RpcServer.toHttpEffect(Api).pipe(
 
 ## Use It As A Payer
 
-Provide `Payer.layerBridge` with `ChxRpc.layer` wherever code should create
+Provide `Payer.layerFromBridge` with `ChxRpc.layer` wherever code should create
 payment payloads through the RPC bridge.
 
 ```ts
@@ -50,9 +50,13 @@ import { Effect, Layer } from "effect"
 
 declare const required: Required.Required
 
-const payerLayer = Payer.layerBridge.pipe(Layer.provideMerge(ChxRpc.layer))
+const layerPayerFromBridge = Payer.layerFromBridge.pipe(
+  Layer.provideMerge(ChxRpc.layer),
+)
 
-const program = Payload.make({ required }).pipe(Effect.provide(payerLayer))
+const program = Payload.make({ required }).pipe(
+  Effect.provide(layerPayerFromBridge),
+)
 ```
 
 When `Payload.make` calls the bridge, `ChxRpc.layer` publishes a `Propose` event

--- a/docs/src/pages/eip155.mdx
+++ b/docs/src/pages/eip155.mdx
@@ -63,7 +63,7 @@ import { Eip155Address } from "crosshatch/Eip155"
 import { Effect } from "effect"
 
 const address = Effect.gen(function* () {
-  const mnemonic = yield* Mnemonic.env
+  const mnemonic = yield* Mnemonic.fromEnv
   return yield* Eip155Address.fromMnemonic(mnemonic)
 })
 ```

--- a/docs/src/pages/eip155.mdx
+++ b/docs/src/pages/eip155.mdx
@@ -47,8 +47,8 @@ import { Mnemonic } from "crosshatch"
 import { Eip155Signer } from "crosshatch/Eip155"
 import { Layer } from "effect"
 
-const Eip155SignerLive = Eip155Signer.layerMnemonic.pipe(
-  Layer.provide(Mnemonic.layerEnv),
+const layerEip155SignerFromMnemonic = Eip155Signer.layerFromMnemonic.pipe(
+  Layer.provide(Mnemonic.layerFromEnv),
 )
 ```
 
@@ -78,8 +78,8 @@ const address = Effect.gen(function* () {
 import { Eip155Signer, Erc3009Scheme } from "crosshatch/Eip155"
 import { Layer } from "effect"
 
-const Erc3009Live = Erc3009Scheme.layer.pipe(
-  Layer.provide(Eip155Signer.layerMnemonic),
+const layerErc3009Scheme = Erc3009Scheme.layer.pipe(
+  Layer.provide(Eip155Signer.layerFromMnemonic),
 )
 ```
 
@@ -96,8 +96,8 @@ data with the `Eip155Signer` service.
 import { Eip155Signer, Permit2Scheme } from "crosshatch/Eip155"
 import { Layer } from "effect"
 
-const Permit2Live = Permit2Scheme.layer.pipe(
-  Layer.provide(Eip155Signer.layerMnemonic),
+const layerPermit2Scheme = Permit2Scheme.layer.pipe(
+  Layer.provide(Eip155Signer.layerFromMnemonic),
 )
 ```
 

--- a/docs/src/pages/extension.mdx
+++ b/docs/src/pages/extension.mdx
@@ -128,7 +128,10 @@ import { PaymentId } from "crosshatch/Extensions"
 
 declare const payload: Payload.Payload
 
-const ExtensionLive = Extension.layerPayload(PaymentId.FromMerchant, payload)
+const layerExtensionFromPayload = Extension.layerFromPayload(
+  PaymentId.FromMerchant,
+  payload,
+)
 ```
 
 At the wire-envelope level, extension maps are JSON records keyed by extension

--- a/docs/src/pages/facilitation.mdx
+++ b/docs/src/pages/facilitation.mdx
@@ -24,7 +24,7 @@ import { Facilitator } from "crosshatch"
 import { Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 
-const FacilitatorLive = Facilitator.layer().pipe(
+const layerFacilitator = Facilitator.layer().pipe(
   Layer.provide(FetchHttpClient.layer),
 )
 ```

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -97,7 +97,7 @@ import { ChxHttp, Payer } from "crosshatch"
 import { Console, Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 
-declare const PayerLive: Layer.Layer<Payer.Payer>
+declare const layerPayerLocal: Layer.Layer<Payer.Payer>
 
 Effect.gen(function* () {
   const client = yield* HttpClient.HttpClient
@@ -107,7 +107,7 @@ Effect.gen(function* () {
   const body = yield* response.text
   yield* Console.log(body)
 }).pipe(
-  Effect.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))),
+  Effect.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayerLocal))),
   Effect.runFork,
 )
 ```
@@ -201,9 +201,9 @@ import { ChxHttp, Payer } from "crosshatch"
 import { Console, Effect, Layer } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 
-declare const PayerLive: Layer.Layer<Payer.Payer>
+declare const layerPayerLocal: Layer.Layer<Payer.Payer>
 
-const BlockrunLive = OpenAiLanguageModel.layer({
+const layerLanguageModelBlockrun = OpenAiLanguageModel.layer({
   model: "deepseek/deepseek-chat",
 }).pipe(
   Layer.provide(OpenAiClient.layer({ apiUrl: "https://blockrun.ai/api/v1" })),
@@ -214,8 +214,8 @@ LanguageModel.generateText({
 }).pipe(
   Effect.tap(({ text }) => Console.log(text)),
   Effect.provide(
-    BlockrunLive.pipe(
-      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))),
+    layerLanguageModelBlockrun.pipe(
+      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayerLocal))),
     ),
   ),
   Effect.runFork,
@@ -247,15 +247,15 @@ import { Accept, Known, Mnemonic, Payer } from "crosshatch"
 import { Eip155Signer, Erc3009Scheme, Permit2Scheme } from "crosshatch/Eip155"
 import { Layer } from "effect"
 
-const SchemesLive = Layer.mergeAll(
+const layerSchemes = Layer.mergeAll(
   Erc3009Scheme.layer,
   Permit2Scheme.layer,
-).pipe(Layer.provide(Eip155Signer.layerMnemonic))
+).pipe(Layer.provide(Eip155Signer.layerFromMnemonic))
 
-export const PayerLive = Payer.layerLocal({
+export const layerPayerLocal = Payer.layerLocal({
   accept: Accept.first(Known),
-  schemes: SchemesLive,
-}).pipe(Layer.provide(Mnemonic.layerEnv))
+  schemes: layerSchemes,
+}).pipe(Layer.provide(Mnemonic.layerFromEnv))
 ```
 
     </div>

--- a/docs/src/pages/mnemonic.mdx
+++ b/docs/src/pages/mnemonic.mdx
@@ -72,7 +72,7 @@ import { Mnemonic } from "crosshatch"
 import { Effect } from "effect"
 
 const program = Effect.gen(function* () {
-  return yield* Mnemonic.env
+  return yield* Mnemonic.fromEnv
 })
 
 const layerMnemonicFromEnv = Mnemonic.layerFromEnv

--- a/docs/src/pages/mnemonic.mdx
+++ b/docs/src/pages/mnemonic.mdx
@@ -20,10 +20,10 @@ import { Eip155Signer } from "crosshatch/Eip155"
 import { SolanaSigner } from "crosshatch/Solana"
 import { Layer } from "effect"
 
-const SignersLive = Layer.mergeAll(
-  Eip155Signer.layerMnemonic,
-  SolanaSigner.layerMnemonic,
-).pipe(Layer.provide(Mnemonic.layerEnv))
+const layerSignersFromMnemonic = Layer.mergeAll(
+  Eip155Signer.layerFromMnemonic,
+  SolanaSigner.layerFromMnemonic,
+).pipe(Layer.provide(Mnemonic.layerFromEnv))
 ```
 
 ## From Text
@@ -41,26 +41,28 @@ const mnemonic = Mnemonic.fromText(
 )
 ```
 
-Use `layerText` to provide that phrase as the `Mnemonic` service.
+Use `layerFromText` to provide that phrase as the `Mnemonic` service.
 
 ```ts
 import { Mnemonic } from "crosshatch"
 
-const MnemonicLive = Mnemonic.layerText(
+const layerMnemonicFromText = Mnemonic.layerFromText(
   "test test test test test test test test test test test junk",
 )
 ```
 
 ## From Config
 
-Use `fromConfig` and `layerConfig` when the phrase comes from an Effect config
-source.
+Use `fromConfig` and `layerFromConfig` when the phrase comes from an Effect
+config source.
 
 ```ts
 import { Config } from "effect"
 import { Mnemonic } from "crosshatch"
 
-const MnemonicLive = Mnemonic.layerConfig(Config.string("BUYER_MNEMONIC"))
+const layerMnemonicFromConfig = Mnemonic.layerFromConfig(
+  Config.string("BUYER_MNEMONIC"),
+)
 ```
 
 The default environment variable helpers read `MNEMONIC`.
@@ -73,7 +75,7 @@ const program = Effect.gen(function* () {
   return yield* Mnemonic.env
 })
 
-const MnemonicLive = Mnemonic.layerEnv
+const layerMnemonicFromEnv = Mnemonic.layerFromEnv
 ```
 
 ## Random Mnemonics
@@ -91,5 +93,5 @@ const program = Effect.gen(function* () {
 ```
 
 Use random mnemonics for tests or disposable local flows. For real payer
-clients, persist the mnemonic securely and provide it with `layerEnv`,
-`layerConfig`, or your own layer.
+clients, persist the mnemonic securely and provide it with `layerFromEnv`,
+`layerFromConfig`, or your own layer.

--- a/docs/src/pages/payer.mdx
+++ b/docs/src/pages/payer.mdx
@@ -18,15 +18,15 @@ import { Accept, Known, Mnemonic, Payer } from "crosshatch"
 import { Eip155Signer, Erc3009Scheme, Permit2Scheme } from "crosshatch/Eip155"
 import { Layer } from "effect"
 
-const SchemesLive = Layer.mergeAll(
+const layerSchemes = Layer.mergeAll(
   Erc3009Scheme.layer,
   Permit2Scheme.layer,
-).pipe(Layer.provide(Eip155Signer.layerMnemonic))
+).pipe(Layer.provide(Eip155Signer.layerFromMnemonic))
 
-const PayerLive = Payer.layerLocal({
+const layerPayerLocal = Payer.layerLocal({
   accept: Accept.first({ USD: Known.USD }),
-  schemes: SchemesLive,
-}).pipe(Layer.provide(Mnemonic.layerEnv))
+  schemes: layerSchemes,
+}).pipe(Layer.provide(Mnemonic.layerFromEnv))
 ```
 
 This example reads `MNEMONIC` from the environment. Other `Mnemonic` layers can
@@ -73,6 +73,6 @@ Unknown extensions and extension values that fail schema decoding are skipped.
 ## Bridge Payer
 
 If payment creation should be delegated to another agent, provide
-`Payer.layerBridge` with a `Bridge` implementation. That keeps HTTP and
+`Payer.layerFromBridge` with a `Bridge` implementation. That keeps HTTP and
 `Payload.make` integrations Payer-based while allowing signing and user approval
 to live elsewhere.

--- a/docs/src/pages/payload.mdx
+++ b/docs/src/pages/payload.mdx
@@ -114,5 +114,5 @@ Provide a `Payer` layer when running the program. See [Payer Service](/payer)
 for local signing and bridge-backed payer setup.
 
 To delegate payload creation to an external wallet, browser extension, or other
-agent, provide `Payer.layerBridge` with a `Bridge` implementation instead of a
-local signing chain.
+agent, provide `Payer.layerFromBridge` with a `Bridge` implementation instead of
+a local signing chain.

--- a/docs/src/pages/quickstart/for-clients.mdx
+++ b/docs/src/pages/quickstart/for-clients.mdx
@@ -33,9 +33,9 @@ import { ChxHttp, Payer } from "crosshatch"
 import { Console, Effect, Layer } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 
-declare const PayerLive: Layer.Layer<Payer.Payer>
+declare const layerPayerLocal: Layer.Layer<Payer.Payer>
 
-const BlockrunLive = OpenAiLanguageModel.layer({
+const layerLanguageModelBlockrun = OpenAiLanguageModel.layer({
   model: "deepseek/deepseek-chat",
 }).pipe(
   Layer.provide(OpenAiClient.layer({ apiUrl: "https://blockrun.ai/api/v1" })),
@@ -46,8 +46,8 @@ LanguageModel.generateText({
 }).pipe(
   Effect.tap(({ text }) => Console.log(text)),
   Effect.provide(
-    BlockrunLive.pipe(
-      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))),
+    layerLanguageModelBlockrun.pipe(
+      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayerLocal))),
     ),
   ),
   Effect.runFork,
@@ -57,15 +57,15 @@ LanguageModel.generateText({
 ## Fetch a Paid Resource
 
 The same layer also works with ordinary Effect HTTP requests. If the first
-response is `402`, Crosshatch reads the payment requirement, asks `PayerLive`
-for a payload, and retries once with the payment header attached.
+response is `402`, Crosshatch reads the payment requirement, asks the `Payer`
+service for a payload, and retries once with the payment header attached.
 
 ```ts
 import { ChxHttp, Payer } from "crosshatch"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 
-declare const PayerLive: Layer.Layer<Payer.Payer>
+declare const layerPayerLocal: Layer.Layer<Payer.Payer>
 
 const program = Effect.gen(function* () {
   const client = yield* HttpClient.HttpClient
@@ -73,10 +73,12 @@ const program = Effect.gen(function* () {
     "https://example.com/paid",
   ).pipe(client.execute)
   return yield* response.text
-}).pipe(Effect.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))))
+}).pipe(
+  Effect.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayerLocal))),
+)
 ```
 
-`PayerLive` wires the payer to supported assets and signers. This example
+`layerPayerLocal` wires the payer to supported assets and signers. This example
 includes known USD assets, EIP-3009, Permit2, and Solana support:
 
 ```ts
@@ -85,24 +87,24 @@ import { Eip155Signer, Erc3009Scheme, Permit2Scheme } from "crosshatch/Eip155"
 import { SolanaScheme, SolanaSigner, SolanaState } from "crosshatch/Solana"
 import { Config, Layer } from "effect"
 
-const SolanaStateLive = Config.string("SOLANA_RPC_URL").pipe(
+const layerSolanaStateFromConfig = Config.string("SOLANA_RPC_URL").pipe(
   Config.map(SolanaState.layer),
   Layer.unwrap,
 )
 
-const SchemesLive = Layer.mergeAll(
+const layerSchemes = Layer.mergeAll(
   Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(
-    Layer.provide(Eip155Signer.layerMnemonic),
+    Layer.provide(Eip155Signer.layerFromMnemonic),
   ),
   SolanaScheme.layer.pipe(
-    Layer.provide([SolanaSigner.layerMnemonic, SolanaStateLive]),
+    Layer.provide([SolanaSigner.layerFromMnemonic, layerSolanaStateFromConfig]),
   ),
 )
 
-export const PayerLive = Payer.layerLocal({
+export const layerPayerLocal = Payer.layerLocal({
   accept: Accept.first(Known),
-  schemes: SchemesLive,
-}).pipe(Layer.provide(Mnemonic.layerEnv))
+  schemes: layerSchemes,
+}).pipe(Layer.provide(Mnemonic.layerFromEnv))
 ```
 
 Set `MNEMONIC` for the signer keys and `SOLANA_RPC_URL` for recent Solana

--- a/docs/src/pages/solana.mdx
+++ b/docs/src/pages/solana.mdx
@@ -38,8 +38,8 @@ import { Mnemonic } from "crosshatch"
 import { SolanaSigner } from "crosshatch/Solana"
 import { Layer } from "effect"
 
-const SolanaSignerLive = SolanaSigner.layerMnemonic.pipe(
-  Layer.provide(Mnemonic.layerEnv),
+const layerSolanaSignerFromMnemonic = SolanaSigner.layerFromMnemonic.pipe(
+  Layer.provide(Mnemonic.layerFromEnv),
 )
 ```
 
@@ -54,7 +54,7 @@ Provide `SolanaState` anywhere you provide `SolanaScheme.layer`.
 import { Config, Layer } from "effect"
 import { SolanaState } from "crosshatch/Solana"
 
-const SolanaStateLive = Config.string("SOLANA_RPC_URL").pipe(
+const layerSolanaStateFromConfig = Config.string("SOLANA_RPC_URL").pipe(
   Config.map(SolanaState.layer),
   Layer.unwrap,
 )
@@ -73,13 +73,13 @@ include a memo.
 import { SolanaScheme, SolanaSigner, SolanaState } from "crosshatch/Solana"
 import { Config, Layer } from "effect"
 
-const SolanaStateLive = Config.string("SOLANA_RPC_URL").pipe(
+const layerSolanaStateFromConfig = Config.string("SOLANA_RPC_URL").pipe(
   Config.map(SolanaState.layer),
   Layer.unwrap,
 )
 
-const SolanaLive = SolanaScheme.layer.pipe(
-  Layer.provide([SolanaSigner.layerMnemonic, SolanaStateLive]),
+const layerSolanaScheme = SolanaScheme.layer.pipe(
+  Layer.provide([SolanaSigner.layerFromMnemonic, layerSolanaStateFromConfig]),
 )
 ```
 

--- a/examples/effect-rpc/ExampleEffectRpc.ts
+++ b/examples/effect-rpc/ExampleEffectRpc.ts
@@ -57,7 +57,7 @@ export default class ExampleEffectRpc extends Cloudflare.RpcWorker<ExampleEffect
             }
             return "bar"
           }, Effect.orDie),
-        ).pipe(Layer.provideMerge(Payer.layerBridge.pipe(Layer.provideMerge(ChxRpc.layer)))),
+        ).pipe(Layer.provideMerge(Payer.layerFromBridge.pipe(Layer.provideMerge(ChxRpc.layer)))),
         RpcSerialization.layerJson,
         Facilitator.layer(),
       ]),

--- a/examples/headless/ai.ts
+++ b/examples/headless/ai.ts
@@ -3,14 +3,14 @@ import { ChxHttp } from "crosshatch"
 import { Console, Effect, Layer } from "effect"
 import { LanguageModel } from "effect/unstable/ai"
 
-import { PayerLive } from "./PayerLive.ts"
+import { layerPayerLocal } from "./layerPayerLocal.ts"
 
-const BlockrunLive = OpenAiLanguageModel.layer({
+const layerLanguageModelBlockrun = OpenAiLanguageModel.layer({
   model: "deepseek/deepseek-chat",
 }).pipe(
   Layer.provide(
     OpenAiClient.layer({ apiUrl: "https://blockrun.ai/api/v1" }).pipe(
-      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(PayerLive))),
+      Layer.provide(ChxHttp.layerClient.pipe(Layer.provide(layerPayerLocal))),
     ),
   ),
 )
@@ -19,7 +19,7 @@ LanguageModel.generateText({
   prompt: "Hello from Crosshatch.",
 }).pipe(
   Effect.tap(({ text }) => Console.log(text)),
-  Effect.provide(BlockrunLive),
+  Effect.provide(layerLanguageModelBlockrun),
   Effect.onError(Effect.logError),
   Effect.runFork,
 )

--- a/examples/headless/basic.ts
+++ b/examples/headless/basic.ts
@@ -3,7 +3,7 @@ import { Eip155Address } from "crosshatch/Eip155"
 import { Config, Effect, Layer, Console } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 
-import { PayerLive } from "./PayerLive.ts"
+import { layerPayerLocal } from "./layerPayerLocal.ts"
 
 Effect.gen(function* () {
   const recipient = yield* Config.schema(Eip155Address.Eip155Address, "PAY_TO_EIP155")
@@ -24,7 +24,7 @@ Effect.gen(function* () {
   const settlement = yield* Facilitator.settle({ payload })
   yield* Console.log(settlement)
 }).pipe(
-  Effect.provide([Facilitator.layer().pipe(Layer.provide(FetchHttpClient.layer)), PayerLive]),
+  Effect.provide([Facilitator.layer().pipe(Layer.provide(FetchHttpClient.layer)), layerPayerLocal]),
   Effect.onError(Effect.logError),
   Effect.runFork,
 )

--- a/examples/headless/extensions.ts
+++ b/examples/headless/extensions.ts
@@ -4,7 +4,7 @@ import { PaymentId } from "crosshatch/Extensions"
 import { Config, Effect, Layer, Console } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 
-import { PayerLive } from "./PayerLive.ts"
+import { layerPayerLocal } from "./layerPayerLocal.ts"
 
 // Merchants make the required with extension info.
 const makeRequired = Effect.gen(function* () {
@@ -34,7 +34,7 @@ Effect.gen(function* () {
 }).pipe(
   Effect.provide([
     Facilitator.layer().pipe(Layer.provideMerge(FetchHttpClient.layer)),
-    PayerLive.pipe(
+    layerPayerLocal.pipe(
       Layer.provide(
         Extension.layerHandler(
           PaymentId.FromMerchant,

--- a/examples/headless/layerPayerLocal.ts
+++ b/examples/headless/layerPayerLocal.ts
@@ -3,7 +3,7 @@ import { HostMnemonic } from "crosshatch/Host"
 import { UnifiedSchemes } from "crosshatch/Unified"
 import { Config, Layer } from "effect"
 
-export const PayerLive = Payer.layerLocal({
+export const layerPayerLocal = Payer.layerLocal({
   accept: Accept.first(Known),
   schemes: UnifiedSchemes.layer({
     solana: { rpc: Config.string("SOLANA_RPC_URL").pipe(Config.withDefault(undefined)) },


### PR DESCRIPTION
Add EURC, JPYC, and XSGD currency support, improve Permit2 authorization
generation, and standardize layer naming across the API, documentation, and
examples.