### PR TITLE
simplify `UnifiedScheme` layer composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,23 @@ single mnemonic `MNEMONIC` in the environment variables.
 ```ts
 import { Accept, Payer, Mnemonic } from "crosshatch"
 import * as Known from "crosshatch/Known"
+import { SolanaState } from "crosshatch/Solana"
 import { UnifiedSchemes } from "crosshatch/Unified"
-import { Config, Layer } from "effect"
+import { Config, Effect, Layer } from "effect"
 
-export const layer = Payer.layerLocal({
-  accept: Accept.first(Known),
-  schemes: UnifiedSchemes.layer({
-    solana: {
-      rpc: Config.string("SOLANA_RPC_URL").pipe(Config.withDefault(undefined)),
-    },
-  }).pipe(Layer.provide(Mnemonic.layerFromEnv)),
-})
+export const layer = Payer.layerLocal(Accept.first(Known)).pipe(
+  Layer.provide(
+    UnifiedSchemes.layer.pipe(
+      Layer.provide([
+        Config.string("SOLANA_RPC_URL").pipe(
+          Effect.map(SolanaState.layer),
+          Layer.unwrap,
+        ),
+        Mnemonic.layerFromEnv,
+      ]),
+    ),
+  ),
+)
 ```
 
 ## Contributing

--- a/crosshatch/Cli/payload/payload_make.ts
+++ b/crosshatch/Cli/payload/payload_make.ts
@@ -7,6 +7,7 @@ import * as Known from "../../Known/index.ts"
 import * as Payer from "../../Payer.ts"
 import * as Payload from "../../Payload.ts"
 import * as Required from "../../Required.ts"
+import { SolanaState } from "../../Solana/index.ts"
 import { UnifiedSchemes } from "../../Unified/index.ts"
 import * as Input from "../Input.ts"
 
@@ -25,7 +26,7 @@ export const payloadMake = Command.make("make", {
         yield* Input.read(required, stdin, "required").pipe(
           Effect.flatMap(S.decodeEffect(Required.RequiredFromJsonString)),
           Effect.flatMap((required) => payer.createPayload({ required })),
-          Effect.flatMap(({ payload }) => S.encodeEffect(Payload.PayloadJson)(payload)),
+          Effect.flatMap((v) => S.encodeEffect(Payload.PayloadJson)(v.payload)),
           Effect.map((v) => JSON.stringify(v, null, 2)),
           Effect.andThen(Console.log),
         )
@@ -35,9 +36,16 @@ export const payloadMake = Command.make("make", {
           effect,
           Payer.layerLocal(Accept.first(Known)).pipe(
             Layer.provide(
-              UnifiedSchemes.layer({
-                solana: { rpc: Config.string("SOLANA_RPC_URL").pipe(Config.withDefault(undefined)) },
-              }).pipe(Layer.provide(MnemonicStore.layerMnemonicFromName(mnemonic))),
+              UnifiedSchemes.layer.pipe(
+                Layer.provide([
+                  Config.string("SOLANA_RPC_URL").pipe(
+                    Config.withDefault(undefined),
+                    Effect.map((v) => (v ? SolanaState.layer(v) : Layer.empty)),
+                    Layer.unwrap,
+                  ),
+                  MnemonicStore.layerMnemonicFromName(mnemonic),
+                ]),
+              ),
             ),
           ),
         ),

--- a/crosshatch/Unified/UnifiedSchemes.ts
+++ b/crosshatch/Unified/UnifiedSchemes.ts
@@ -1,27 +1,9 @@
-import { Layer, Config, Effect, UndefinedOr } from "effect"
+import { Layer } from "effect"
 
 import { Erc3009Scheme, Eip155Signer, Permit2Scheme } from "../Eip155/index.ts"
-import { SolanaScheme, SolanaSigner, SolanaState } from "../Solana/index.ts"
+import { SolanaScheme, SolanaSigner } from "../Solana/index.ts"
 
-export interface UnifiedSchemesConfig {
-  readonly solana?: {
-    readonly rpc: string | undefined | Config.Config<string | undefined>
-  }
-}
-
-export const layer = (config?: UnifiedSchemesConfig) =>
-  Layer.mergeAll(
-    Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(Layer.provide(Eip155Signer.layerFromMnemonic)),
-    config?.solana
-      ? (Config.isConfig(config.solana.rpc) ? config.solana.rpc : Config.succeed(config.solana.rpc)).pipe(
-          Effect.map(
-            UndefinedOr.match({
-              onDefined: (v) =>
-                SolanaScheme.layer.pipe(Layer.provide([SolanaSigner.layerFromMnemonic, SolanaState.layer(v)])),
-              onUndefined: () => Layer.empty,
-            }),
-          ),
-          Layer.unwrap,
-        )
-      : Layer.empty,
-  )
+export const layer = Layer.mergeAll(
+  Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(Layer.provide(Eip155Signer.layerFromMnemonic)),
+  SolanaScheme.layer.pipe(Layer.provide(SolanaSigner.layerFromMnemonic)),
+)

--- a/crosshatch/Unified/UnifiedSchemes.ts
+++ b/crosshatch/Unified/UnifiedSchemes.ts
@@ -1,9 +1,20 @@
-import { Layer } from "effect"
+import { Effect, Layer, Option } from "effect"
 
 import { Erc3009Scheme, Eip155Signer, Permit2Scheme } from "../Eip155/index.ts"
-import { SolanaScheme, SolanaSigner } from "../Solana/index.ts"
+import { SolanaScheme, SolanaSigner, SolanaState } from "../Solana/index.ts"
 
 export const layer = Layer.mergeAll(
   Layer.mergeAll(Erc3009Scheme.layer, Permit2Scheme.layer).pipe(Layer.provide(Eip155Signer.layerFromMnemonic)),
-  SolanaScheme.layer.pipe(Layer.provide(SolanaSigner.layerFromMnemonic)),
+  Effect.serviceOption(SolanaState.SolanaState).pipe(
+    Effect.map(
+      Option.match({
+        onSome: (v) =>
+          SolanaScheme.layer.pipe(
+            Layer.provide([SolanaSigner.layerFromMnemonic, Layer.succeed(SolanaState.SolanaState, v)]),
+          ),
+        onNone: () => Layer.empty,
+      }),
+    ),
+    Layer.unwrap,
+  ),
 )

--- a/docs/src/pages/quickstart/for-clients.mdx
+++ b/docs/src/pages/quickstart/for-clients.mdx
@@ -81,27 +81,28 @@ const program = Effect.gen(function* () {
 `layerPayerLocal` wires the payer to supported assets and signers. In Node.js,
 the built-in services load a named mnemonic encrypted at rest, with its
 encryption key kept in the operating system keychain. This example uses the
-`default` mnemonic and includes known USD assets, EIP-3009, Permit2, and
-optional Solana support:
+`default` mnemonic and includes known USD assets, EIP-3009, Permit2, and Solana
+support:
 
 ```ts
 import { NodeServices } from "@effect/platform-node"
 import { Accept, MnemonicStore, Payer } from "crosshatch"
 import * as ChxNodeServices from "crosshatch/ChxNodeServices"
 import * as Known from "crosshatch/Known"
+import { SolanaState } from "crosshatch/Solana"
 import { UnifiedSchemes } from "crosshatch/Unified"
-import { Config, Layer } from "effect"
+import { Config, Effect, Layer } from "effect"
 
-const layerSchemes = UnifiedSchemes.layer({
-  solana: {
-    rpc: Config.string("SOLANA_RPC_URL").pipe(Config.withDefault(undefined)),
-  },
-}).pipe(
-  Layer.provide(
+const layerSchemes = UnifiedSchemes.layer.pipe(
+  Layer.provide([
+    Config.string("SOLANA_RPC_URL").pipe(
+      Effect.map(SolanaState.layer),
+      Layer.unwrap,
+    ),
     MnemonicStore.layerMnemonicFromName().pipe(
       Layer.provide(ChxNodeServices.layer),
     ),
-  ),
+  ]),
 )
 
 export const layerPayerLocal = Payer.layerLocal(Accept.first(Known)).pipe(
@@ -112,8 +113,8 @@ export const layerPayerLocal = Payer.layerLocal(Accept.first(Known)).pipe(
 
 Create the default mnemonic with `pnpm crosshatch mnemonic add`. Pass a name to
 both the command and `MnemonicStore.layerMnemonicFromName(name)` to use another
-account. Set `SOLANA_RPC_URL` to enable Solana payments. See [Payer](/payer) for
-custom asset, policy, and scheme composition.
+account. Set `SOLANA_RPC_URL` to the Solana JSON-RPC endpoint used when creating
+payments. See [Payer](/payer) for custom asset, policy, and scheme composition.
 
 ## Delegate Payment Creation
 

--- a/docs/src/pages/solana.mdx
+++ b/docs/src/pages/solana.mdx
@@ -88,4 +88,25 @@ const layerSolanaScheme = SolanaScheme.layer.pipe(
 A Solana-capable payer provides the Solana scheme, signer, chain state service,
 and denomination.
 
+`UnifiedSchemes.layer` includes Solana alongside the built-in EIP-3009 and
+Permit2 schemes. It is a layer value rather than a configuration function, so
+provide its mnemonic and Solana state dependencies directly:
+
+```ts
+import { Mnemonic } from "crosshatch"
+import { SolanaState } from "crosshatch/Solana"
+import { UnifiedSchemes } from "crosshatch/Unified"
+import { Config, Effect, Layer } from "effect"
+
+const layerUnifiedSchemes = UnifiedSchemes.layer.pipe(
+  Layer.provide([
+    Mnemonic.layerFromEnv,
+    Config.string("SOLANA_RPC_URL").pipe(
+      Effect.map(SolanaState.layer),
+      Layer.unwrap,
+    ),
+  ]),
+)
+```
+
 See [Payer Service](/payer) for the full composition pattern.

--- a/examples/headless/layerPrelude.ts
+++ b/examples/headless/layerPrelude.ts
@@ -1,14 +1,16 @@
 import { Accept, Payer, Mnemonic } from "crosshatch"
 import * as Known from "crosshatch/Known"
+import { SolanaState } from "crosshatch/Solana"
 import { UnifiedSchemes } from "crosshatch/Unified"
-import { Config, Layer } from "effect"
+import { Config, Effect, Layer } from "effect"
 
 export const layerPrelude = Payer.layerLocal(Accept.first(Known)).pipe(
   Layer.provide(
-    UnifiedSchemes.layer({
-      solana: {
-        rpc: Config.string("SOLANA_RPC_URL").pipe(Config.withDefault(undefined)),
-      },
-    }).pipe(Layer.provide(Mnemonic.layerFromEnv)),
+    UnifiedSchemes.layer.pipe(
+      Layer.provide([
+        Config.string("SOLANA_RPC_URL").pipe(Effect.map(SolanaState.layer), Layer.unwrap),
+        Mnemonic.layerFromEnv,
+      ]),
+    ),
   ),
 )


### PR DESCRIPTION
`UnifiedSchemes.layer` changes from a factory into an Effect Layer.

Previously, callers passed Solana RPC configuration:

```ts
UnifiedSchemes.layer({ solana: { rpc } }).pipe(
  Layer.provide(Mnemonic.layerFromEnv),
)
```

Now, callers (optionally) provide `SolanaState` through standard layer composition:

```ts
UnifiedSchemes.layer.pipe(
  Layer.provide([
    Mnemonic.layerFromEnv,
    SolanaState.layer(rpc)
  ]),
)
```

EIP-3009 and Permit2 remain built in. Solana support is included automatically when a `SolanaState` service is available; otherwise it is omitted.